### PR TITLE
updated for newer ESP IDF versions

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(SRCS "OLEDDisplay.c" 
-										"OLEDDisplayFonts.c"
-                    INCLUDE_DIRS "./include")
+									"OLEDDisplayFonts.c"
+									REQUIRES driver
+									INCLUDE_DIRS "." "include")

--- a/components/OLEDDisplay.c
+++ b/components/OLEDDisplay.c
@@ -161,7 +161,7 @@ static void OLEDDisplay_sendCommand(OLEDDisplay_t *oled, uint8_t opcode)
     i2c_master_write_byte(cmd, 0x80, BKG_ACK_CHECK  );
     i2c_master_write_byte(cmd, opcode,  BKG_ACK_CHECK  );
     i2c_master_stop(cmd);
-    esp_err_t ret = i2c_master_cmd_begin(oled->i2c_port, cmd, 1000 / portTICK_RATE_MS);
+    esp_err_t ret = i2c_master_cmd_begin(oled->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
 }
 
@@ -182,7 +182,7 @@ static void OLEDDisplay_i2cwrite(OLEDDisplay_t *oled,uint8_t d)
 static esp_err_t OLEDDisplay_endPayload(OLEDDisplay_t *oled) {
     i2c_cmd_handle_t cmd = oled->i2c_cmd;
     i2c_master_stop(cmd);
-    esp_err_t ret = i2c_master_cmd_begin(oled->i2c_port, cmd, 1000 / portTICK_RATE_MS);
+    esp_err_t ret = i2c_master_cmd_begin(oled->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
     return ret;
 }
@@ -194,7 +194,7 @@ static esp_err_t OLEDDisplay_sendPayload(OLEDDisplay_t *oled, uint8_t *buf, size
     i2c_master_write_byte(cmd, 0x40, BKG_ACK_CHECK  );
     i2c_master_write(cmd, buf, size, BKG_ACK_CHECK);
     i2c_master_stop(cmd);
-    esp_err_t ret = i2c_master_cmd_begin(oled->i2c_port, cmd, 1000 / portTICK_RATE_MS);
+    esp_err_t ret = i2c_master_cmd_begin(oled->i2c_port, cmd, 1000 / portTICK_PERIOD_MS);
     i2c_cmd_link_delete(cmd);
     return ret;
 }


### PR DESCRIPTION
Changed the "portTICK_RATE_MS" to "portTICK_PERIOD_MS" to work for newer IDF versions.
Also added "REQUIRES driver" in the CMakeLists.txt because it threw an error while compiling without it.